### PR TITLE
fix: keep supporter code write-only in settings API

### DIFF
--- a/src/POE2Radar.Overlay/Web/ApiServer.cs
+++ b/src/POE2Radar.Overlay/Web/ApiServer.cs
@@ -2707,7 +2707,9 @@ public sealed class ApiServer : IDisposable
         // Support — v0.27 (LO ask): supporter code + cosmetic dashboard palette + optional overlay badge.
         // isSupporter is a derived read-only mirror of the honor-system check — the dashboard uses it
         // to gate palette + badge UI, no reveal of the actual code or hash list.
-        supporterCode      = _settings.SupporterCode,
+        // The raw supporter code is write-only. It is accepted by POST /api/settings,
+        // but never echoed through this unauthenticated GET (especially important when
+        // AllowLanAccess is enabled); the dashboard uses the derived isSupporter flag.
         dashboardPalette   = _settings.DashboardPalette,
         paletteColors = POE2Radar.Core.Themes.RecapPaletteMap.Resolve(_settings.DashboardPalette),
         showSupporterBadge = _settings.ShowSupporterBadge,

--- a/tests/POE2Radar.Tests/Web/StreamSafeSettingsTests.cs
+++ b/tests/POE2Radar.Tests/Web/StreamSafeSettingsTests.cs
@@ -49,6 +49,7 @@ public class StreamSafeSettingsTests
             Assert.True(root.GetProperty("webObsSafeMaskZoneName").GetBoolean());
             Assert.True(root.GetProperty("webObsSafeHideoutBlur").GetBoolean());
             Assert.False(root.GetProperty("webObsSafeEntityNameFog").GetBoolean());
+            Assert.False(root.TryGetProperty("supporterCode", out _));
         }
         finally { api.Dispose(); }
     }


### PR DESCRIPTION
PoE2-only maintenance update. The settings API no longer echoes the raw supporter code in GET responses, and the regression test asserts write-only behavior. Targeted security regression: 5 passed, 0 failed; production build passed. This is a draft for upstream review.